### PR TITLE
fix(ui): Request Panel > Body > GraphQL > Default query variables to empty object

### DIFF
--- a/packages/ui/src/components/RequestPanel.vue
+++ b/packages/ui/src/components/RequestPanel.vue
@@ -374,7 +374,7 @@ export default {
                     const parsedBodyText = JSON.parse(this.activeTab.body.text)
                     this.graphql = {
                         query: parsedBodyText.query ?? '',
-                        variables: JSON.stringify(parsedBodyText.variables ?? '{}', null, 4)
+                        variables: JSON.stringify(typeof parsedBodyText.variables === 'object' ? parsedBodyText.variables : {}, null, 4)
                     }
                 } catch {
                     this.graphql = {

--- a/packages/ui/src/components/RequestPanel.vue
+++ b/packages/ui/src/components/RequestPanel.vue
@@ -252,7 +252,7 @@ export default {
             ],
             graphql: {
                 query: '',
-                variables: ''
+                variables: '{}'
             },
             disableGraphqlWatch: false,
             refreshCodeMirrorEditors: 1
@@ -273,7 +273,7 @@ export default {
                     this.disableGraphqlWatch = false
                     return
                 }
-                let graphqlVariables = ''
+                let graphqlVariables = {}
                 try {
                     graphqlVariables = JSON.parse(this.graphql.variables)
                 } catch {}
@@ -374,12 +374,12 @@ export default {
                     const parsedBodyText = JSON.parse(this.activeTab.body.text)
                     this.graphql = {
                         query: parsedBodyText.query ?? '',
-                        variables: parsedBodyText.variables !== '' ? JSON.stringify(parsedBodyText.variables, null, 4) : ''
+                        variables: JSON.stringify(parsedBodyText.variables ?? '{}', null, 4)
                     }
                 } catch {
                     this.graphql = {
                         query: '',
-                        variables: ''
+                        variables: '{}'
                     }
                 }
             }


### PR DESCRIPTION
Change default `graphqlVariables` to empty object to prevent 400 (bad data) when submit with  `graphqlVariables` is empty string