### PR TITLE
Documenting build-desktop target

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,19 @@ Offline-first web HTTP client
 ## ui
 
 ### Development
+```
 npm run dev
+```
 
 ### Distribution
+```
 npm run build
+```
+
+### Desktop distribution and development
+```
+npm run build-desktop
+```
 
 ## electron
 


### PR DESCRIPTION
It's worth to mention about `build-desktop` target which is mandatory for building the desktop application. It's needed during development too.
