### PR TITLE
fix(ui): substitute all occurances of environment variables

### DIFF
--- a/packages/ui/src/helpers.ts
+++ b/packages/ui/src/helpers.ts
@@ -50,9 +50,9 @@ export function substituteEnvironmentVariables(environment, string) {
 
     possibleEnvironmentObjectPaths.forEach(objectPath => {
         const objectPathValue = getObjectPathValue(environment, objectPath)
-        substitutedString = substitutedString.replace(`{{ _.${objectPath} }}`, objectPathValue)
-        substitutedString = substitutedString.replace(`{{${objectPath}}}`, objectPathValue)
-        substitutedString = substitutedString.replace(`{{ ${objectPath} }}`, objectPathValue)
+        substitutedString = substitutedString.replaceAll(`{{ _.${objectPath} }}`, objectPathValue)
+        substitutedString = substitutedString.replaceAll(`{{${objectPath}}}`, objectPathValue)
+        substitutedString = substitutedString.replaceAll(`{{ ${objectPath} }}`, objectPathValue)
     })
 
     return substitutedString


### PR DESCRIPTION
I couldn't find anywhere to put tests. Here's the problem
```
{
    "name": "{{ name }}",
    "emailFooter": "With kind regards, {{ name }}"
}
```
would become
```
{ "name": "simon", "emailFooter": "With kind regards, {{ name }}" }
```
but now becomes
```
{ "name": "simon", "emailFooter": "With kind regards, simon" }
```

Note: `replaceAll` was introduced in es2021, so you might want to provide a polyfill for (very) older browsers - or find some other solution to replace all instances.

Thanks for your time!