### PR TITLE
Handle sidebar request name editing smarter

### DIFF
--- a/packages/ui/src/components/SidebarItem.vue
+++ b/packages/ui/src/components/SidebarItem.vue
@@ -30,7 +30,7 @@
                 @input="updateTemporarySidebarItemName"
                 style="pointer-events: auto; border: 0; outline: 0; width: 100%; padding: 0; background-color: inherit; font-style: italic;"
                 spellcheck="false"
-                @keydown.enter="showInputToRenameRequest = false"
+                @keydown.enter="saveSidebarItemName(sidebarItem); showInputToRenameRequest = false"
                 @blur="saveSidebarItemName(sidebarItem)"
                 @dblclick.stop
                 v-focus

--- a/packages/ui/src/components/SidebarItem.vue
+++ b/packages/ui/src/components/SidebarItem.vue
@@ -31,6 +31,7 @@
                 style="pointer-events: auto; border: 0; outline: 0; width: 100%; padding: 0; background-color: inherit; font-style: italic;"
                 spellcheck="false"
                 @keydown.enter="saveSidebarItemName(sidebarItem); showInputToRenameRequest = false"
+                @keydown.esc="showInputToRenameRequest = false"
                 @blur="saveSidebarItemName(sidebarItem)"
                 @dblclick.stop
                 v-focus


### PR DESCRIPTION
When editing request name in sidebar:

before merge: enter aborts, esc does nothing
after merge:  enter saves, esc aborts