### PR TITLE
Fix: [object Object] in request-body when {{envVariable}} is replaced by an object type

### DIFF
--- a/packages/ui/src/helpers.spec.js
+++ b/packages/ui/src/helpers.spec.js
@@ -1,306 +1,304 @@
 import { assert, test, describe, expect } from 'vitest'
 import { substituteEnvironmentVariables, stringifyArray } from './helpers.ts'
 
-describe ('ui/src/helpers.ts', () => {
 
-    describe(`Function: ${stringifyArray.name}`, () => {
+describe(`Function: ${stringifyArray.name}`, () => {
 
-        const arrObj = [
-            [1,2,3],
-            [ 'a', 'b', 'c' ],
-            { keyObj: { nestedObj: 'nest object value', nestedArr: [ 1, 2, 3 ] } }
-        ]
+    const arrObj = [
+        [1,2,3],
+        [ 'a', 'b', 'c' ],
+        { keyObj: { nestedObj: 'nest object value', nestedArr: [ 1, 2, 3 ] } }
+    ]
 
-        test('Generic Test', () => {
-            function stringifyArrayTestFunction(arr) {
-                const arrStr = JSON.stringify(arr)
-                return arrStr.slice(1, arrStr.length-1)
-            }
+    test('Generic Test', () => {
+        function stringifyArrayTestFunction(arr) {
+            const arrStr = JSON.stringify(arr)
+            return arrStr.slice(1, arrStr.length-1)
+        }
 
-            assert.equal(stringifyArray(arrObj) , stringifyArrayTestFunction(arrObj))
-            for (const subArr of arrObj) {
-                assert.equal(stringifyArray(subArr) , stringifyArrayTestFunction(subArr))
-            }
-        })
+        assert.equal(stringifyArray(arrObj) , stringifyArrayTestFunction(arrObj))
+        for (const subArr of arrObj) {
+            assert.equal(stringifyArray(subArr) , stringifyArrayTestFunction(subArr))
+        }
+    })
+
+})
+
+describe(`Function: ${substituteEnvironmentVariables.name}`, () => {
+
+    // build environment vars
+    const env = {}
+
+    env.i = 1
+    env.num = 1234
+    env.str = 'This is string'
+
+    env.arrNum = [ 1, 2, 3 ]
+    env.arrStr = [ 'a', 'bb', 'cc' ]
+    env.arrObj = [
+        { keyStr: 'string' },
+        { keyNum: 1 },
+        { keyObj: { nestedObj: 'nest object value', nestedArr: [ 1, 2, 3 ] } }
+    ]
+
+    env.arr2dMix= [ env.arrNum, env.arrStr, env.arrObj ]
+
+    env.strCamelCase      = 'This is camelCase'
+    env.str_snake_case    = 'This is snake-case'
+    env['str-kebab-case'] = 'This is kebab-case'
+    env['key with space'] = 'This key has space'
+
+    const extremelyMessyKey = 'extremelyMESSY-K_E_Y ~!@#$%^&*()_+12 34567980{{} :>}notReplaced::{{  num }}::notReplaced"?<, . shouldReplaceThisInFuture::{{  num   }}::replaced /;\'[ ]'
+    env[ extremelyMessyKey ] = 'Very messy key :)'
+
+
+    test('Positive Case', () => {
+        const input =`{
+            "i": {{i}},
+            "_i": {{ i }},
+
+            "num": {{num}},
+            "_num": {{ num }},
+
+            "str": "{{str}}",
+            "_str": "{{ str }}",
+
+            "arrNum": [{{arrNum}}],
+            "_arrNum": [ {{ arrNum }} ],
+            "arrNum[0]": "{{arrNum[0]}}",
+            "_arrNum[0]": "{{ arrNum[0] }}",
+
+            "arrStr": [{{arrStr}}],
+            "arrStr_": [ {{arrStr}} ],
+            "arrStr[0]": "{{arrStr[0]}}",
+
+            "arrObj[0]": "{{arrObj[0]}}",
+            "arrObj[1]": "{{arrObj[1]}}",
+            "arrObj[2]": "{{arrObj[2]}}",
+            "arrObj[2].keyObj": "{{arrObj[2].keyObj}}",
+
+            "arr2dMix": [{{arr2dMix}}],
+            "arr2dMix_": [ {{arr2dMix}} ],
+
+            "arr2dMix[2][2].keyObj.nestedArr": [{{arr2dMix[2][2].keyObj.nestedArr}}],
+            "arr2dMix[2][2].keyObj.nestedArr[0]": {{arr2dMix[2][2].keyObj.nestedArr[0]}},
+
+            "strCamelCase":   "{{strCamelCase}}",
+            "str_snake_case": "{{str_snake_case}}",
+            "str-kebab-case": "{{str-kebab-case}}",
+            "key with space": "{{key with space}}",
+
+            "messyKey": "{{${extremelyMessyKey}}}",
+        }`
+        const expectedOutput = `{
+            "i": ${env.i},
+            "_i": ${env.i},
+
+            "num": ${env.num},
+            "_num": ${env.num},
+
+            "str": "${env.str}",
+            "_str": "${env.str}",
+
+            "arrNum": [${stringifyArray(env.arrNum)}],
+            "_arrNum": [ ${stringifyArray(env.arrNum)} ],
+            "arrNum[0]": "${env.arrNum[0]}",
+            "_arrNum[0]": "${env.arrNum[0]}",
+
+            "arrStr": [${stringifyArray(env.arrStr)}],
+            "arrStr_": [ ${stringifyArray(env.arrStr)} ],
+            "arrStr[0]": "${env.arrStr[0]}",
+
+            "arrObj[0]": "${JSON.stringify(env.arrObj[0])}",
+            "arrObj[1]": "${JSON.stringify(env.arrObj[1])}",
+            "arrObj[2]": "${JSON.stringify(env.arrObj[2])}",
+            "arrObj[2].keyObj": "${JSON.stringify(env.arrObj[2].keyObj)}",
+
+            "arr2dMix": [${stringifyArray(env.arr2dMix)}],
+            "arr2dMix_": [ ${stringifyArray(env.arr2dMix)} ],
+
+            "arr2dMix[2][2].keyObj.nestedArr": [${stringifyArray(env.arr2dMix[2][2].keyObj.nestedArr)}],
+            "arr2dMix[2][2].keyObj.nestedArr[0]": ${env.arr2dMix[2][2].keyObj.nestedArr[0]},
+
+            "strCamelCase":   "${env.strCamelCase}",
+            "str_snake_case": "${env.str_snake_case}",
+            "str-kebab-case": "${env['str-kebab-case']}",
+            "key with space": "${env['key with space']}",
+
+            "messyKey": "${env[extremelyMessyKey]}",
+        }`
+        assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
+    })
+
+    test('Negative Case', () => {
+        const input =`{
+            "": "",
+            "{": "}",
+            "{{": "}}",
+            "}}": "{{",
+            "{": "}}",
+            "{{": "}",
+            "{ { ": " } }",
+
+            "num": num,
+            "num": {num,
+            "num": num},
+            "num": {num},
+            "num": {{num},
+            "num": {num}},
+
+            "num": { {num}},
+            "num": {{num} },
+            "num": { {num} },
+            "num": { {num } },
+            "num": { { num} },
+            "num": { { num } },
+
+            "num": {{ num}},
+            "num": {{num }},
+
+            "num": {{  num}},
+            "num": {{num  }},
+            "num": {{  num }},
+            "num": {{ num  }},
+            "num": {{  num  }},
+
+            "num": {{
+                num}},
+            "num": {{num
+            }},
+            "num": {{
+                num
+            }},
+            "num": {
+                {num}
+            },
+
+            "num": {
+                {num
+            }},
+            "num": {{
+                num}
+            }},
+
+
+            "str": {{ s t r }},
+            "str": {{}},
+            "str": {,
+            "str": {{,
+            "str": {{},
+            "str": {}},
+            "str": {{}},
+            "str": { { } },
+            "str": {  } },
+
+            "-_-": "-_-",
+            "{{}}": "-._.-",
+            "{{}}": "_.",
+            "{{}}": "{{_.}}",
+
+            "{{}}": "{{_. arrNum}}",
+            "{{}}": "{{_ .arrNum}}",
+
+            "{{}}": "{{ _.arrNum  }}",
+            "{{}}": "{{_.arrNum }}",
+            "{{}}": "{{  _.arrNum  }}",
+            "{{}}": "{{  _.arrNum.  }}",
+
+            "{{}}": "{{arrNum.}}",
+            "{{str": "}}",
+            "{{str": }},
+            "arrNum": "{{arrNum[999]}}",
+        }`
+
+        const extraForRegExSpecific =`{
+            "num": {{ num    }}, "num": {{num  }}, "num": {{  num }},
+                                                            "num": {{  num }},
+            "num": {{ num  }},
+            "num": {{
+                num
+            }},
+            "num": {{num
+            }},
+            "num": {{
+                num}},
+            "str": {{ s t r }},
+        }`
+
+        assert.equal(substituteEnvironmentVariables(env, input), input)
+        assert.equal(substituteEnvironmentVariables(env, extraForRegExSpecific), extraForRegExSpecific)
 
     })
 
-    describe(`Function: ${substituteEnvironmentVariables.name}`, () => {
+    test('Insomnia support', () => {
+        const input =`{
+            "num": {{_.num}},
+            "_num": {{ _.num }},
 
-        // build environment vars
-        const env = {}
+            "str": "{{_.str}}",
+            "_str": "{{ _.str }}",
 
-        env.i = 1
-        env.num = 1234
-        env.str = 'This is string'
+            "arr2dMix": [{{_.arr2dMix}}],
+            "arr2dMix_": [ {{ _.arr2dMix }} ],
 
-        env.arrNum = [ 1, 2, 3 ]
-        env.arrStr = [ 'a', 'bb', 'cc' ]
-        env.arrObj = [
-            { keyStr: 'string' },
-            { keyNum: 1 },
-            { keyObj: { nestedObj: 'nest object value', nestedArr: [ 1, 2, 3 ] } }
-        ]
+            "arr2dMix[2][2].keyObj.nestedArr": [{{ _.arr2dMix[2][2].keyObj.nestedArr }}],
+            "arr2dMix[2][2].keyObj.nestedArr[0]": {{_.arr2dMix[2][2].keyObj.nestedArr[0]}},
 
-        env.arr2dMix= [ env.arrNum, env.arrStr, env.arrObj ]
+            "strCamelCase":   "{{_.strCamelCase}}",
+            "str_snake_case": "{{_.str_snake_case}}",
+            "str-kebab-case": "{{_.str-kebab-case}}",
+            "key with space": "{{ _.key with space }}",
 
-        env.strCamelCase      = 'This is camelCase'
-        env.str_snake_case    = 'This is snake-case'
-        env['str-kebab-case'] = 'This is kebab-case'
-        env['key with space'] = 'This key has space'
+            "messyKey": "{{${extremelyMessyKey}}}",
+        }`
+        const expectedOutput = `{
+            "num": ${env.num},
+            "_num": ${env.num},
 
-        const extremelyMessyKey = 'extremelyMESSY-K_E_Y ~!@#$%^&*()_+12 34567980{{} :>}notReplaced::{{  num }}::notReplaced"?<, . shouldReplaceThisInFuture::{{  num   }}::replaced /;\'[ ]'
-        env[ extremelyMessyKey ] = 'Very messy key :)'
+            "str": "${env.str}",
+            "_str": "${env.str}",
 
+            "arr2dMix": [${stringifyArray(env.arr2dMix)}],
+            "arr2dMix_": [ ${stringifyArray(env.arr2dMix)} ],
 
-        test('Positive Case', () => {
-            const input =`{
-                "i": {{i}},
-                "_i": {{ i }},
+            "arr2dMix[2][2].keyObj.nestedArr": [${stringifyArray(env.arr2dMix[2][2].keyObj.nestedArr)}],
+            "arr2dMix[2][2].keyObj.nestedArr[0]": ${env.arr2dMix[2][2].keyObj.nestedArr[0]},
 
-                "num": {{num}},
-                "_num": {{ num }},
+            "strCamelCase":   "${env.strCamelCase}",
+            "str_snake_case": "${env.str_snake_case}",
+            "str-kebab-case": "${env['str-kebab-case']}",
+            "key with space": "${env['key with space']}",
 
-                "str": "{{str}}",
-                "_str": "{{ str }}",
+            "messyKey": "${env[extremelyMessyKey]}",
+        }`
+        assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
+    })
 
-                "arrNum": [{{arrNum}}],
-                "_arrNum": [ {{ arrNum }} ],
-                "arrNum[0]": "{{arrNum[0]}}",
-                "_arrNum[0]": "{{ arrNum[0] }}",
+    test('Insomnia support will not be used if "_" is present as a key in "environment"', () => {
+        env._ = { someKey: '"_" will be used treated as the key, if its present in the env' }
 
-                "arrStr": [{{arrStr}}],
-                "arrStr_": [ {{arrStr}} ],
-                "arrStr[0]": "{{arrStr[0]}}",
+        const input =`{
+            "_.someKey": {{_.someKey}},
+            "_.someKey": {{ _.someKey }},
 
-                "arrObj[0]": "{{arrObj[0]}}",
-                "arrObj[1]": "{{arrObj[1]}}",
-                "arrObj[2]": "{{arrObj[2]}}",
-                "arrObj[2].keyObj": "{{arrObj[2].keyObj}}",
+            "num": {{_.num}},
+            "_.someKey": {{ _.someKey}},
+            "_.someKey": {{_.someKey }},
+            "_.someKey": {{  _.someKey }},
+            "_.someKey": {{ _.someKey  }},
+            "_.someKey": {{  _.someKey  }},
+        }`
+        const expectedOutput = `{
+            "_.someKey": ${env._.someKey},
+            "_.someKey": ${env._.someKey},
 
-                "arr2dMix": [{{arr2dMix}}],
-                "arr2dMix_": [ {{arr2dMix}} ],
-
-                "arr2dMix[2][2].keyObj.nestedArr": [{{arr2dMix[2][2].keyObj.nestedArr}}],
-                "arr2dMix[2][2].keyObj.nestedArr[0]": {{arr2dMix[2][2].keyObj.nestedArr[0]}},
-
-                "strCamelCase":   "{{strCamelCase}}",
-                "str_snake_case": "{{str_snake_case}}",
-                "str-kebab-case": "{{str-kebab-case}}",
-                "key with space": "{{key with space}}",
-
-                "messyKey": "{{${extremelyMessyKey}}}",
-            }`
-            const expectedOutput = `{
-                "i": ${env.i},
-                "_i": ${env.i},
-
-                "num": ${env.num},
-                "_num": ${env.num},
-
-                "str": "${env.str}",
-                "_str": "${env.str}",
-
-                "arrNum": [${stringifyArray(env.arrNum)}],
-                "_arrNum": [ ${stringifyArray(env.arrNum)} ],
-                "arrNum[0]": "${env.arrNum[0]}",
-                "_arrNum[0]": "${env.arrNum[0]}",
-
-                "arrStr": [${stringifyArray(env.arrStr)}],
-                "arrStr_": [ ${stringifyArray(env.arrStr)} ],
-                "arrStr[0]": "${env.arrStr[0]}",
-
-                "arrObj[0]": "${JSON.stringify(env.arrObj[0])}",
-                "arrObj[1]": "${JSON.stringify(env.arrObj[1])}",
-                "arrObj[2]": "${JSON.stringify(env.arrObj[2])}",
-                "arrObj[2].keyObj": "${JSON.stringify(env.arrObj[2].keyObj)}",
-
-                "arr2dMix": [${stringifyArray(env.arr2dMix)}],
-                "arr2dMix_": [ ${stringifyArray(env.arr2dMix)} ],
-
-                "arr2dMix[2][2].keyObj.nestedArr": [${stringifyArray(env.arr2dMix[2][2].keyObj.nestedArr)}],
-                "arr2dMix[2][2].keyObj.nestedArr[0]": ${env.arr2dMix[2][2].keyObj.nestedArr[0]},
-
-                "strCamelCase":   "${env.strCamelCase}",
-                "str_snake_case": "${env.str_snake_case}",
-                "str-kebab-case": "${env['str-kebab-case']}",
-                "key with space": "${env['key with space']}",
-
-                "messyKey": "${env[extremelyMessyKey]}",
-            }`
-            assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
-        })
-
-        test('Negative Case', () => {
-            const input =`{
-                "": "",
-                "{": "}",
-                "{{": "}}",
-                "}}": "{{",
-                "{": "}}",
-                "{{": "}",
-                "{ { ": " } }",
-
-                "num": num,
-                "num": {num,
-                "num": num},
-                "num": {num},
-                "num": {{num},
-                "num": {num}},
-
-                "num": { {num}},
-                "num": {{num} },
-                "num": { {num} },
-                "num": { {num } },
-                "num": { { num} },
-                "num": { { num } },
-
-                "num": {{ num}},
-                "num": {{num }},
-
-                "num": {{  num}},
-                "num": {{num  }},
-                "num": {{  num }},
-                "num": {{ num  }},
-                "num": {{  num  }},
-
-                "num": {{
-                    num}},
-                "num": {{num
-                }},
-                "num": {{
-                    num
-                }},
-                "num": {
-                    {num}
-                },
-
-                "num": {
-                    {num
-                }},
-                "num": {{
-                    num}
-                }},
-
-
-                "str": {{ s t r }},
-                "str": {{}},
-                "str": {,
-                "str": {{,
-                "str": {{},
-                "str": {}},
-                "str": {{}},
-                "str": { { } },
-                "str": {  } },
-
-                "-_-": "-_-",
-                "{{}}": "-._.-",
-                "{{}}": "_.",
-                "{{}}": "{{_.}}",
-
-                "{{}}": "{{_. arrNum}}",
-                "{{}}": "{{_ .arrNum}}",
-
-                "{{}}": "{{ _.arrNum  }}",
-                "{{}}": "{{_.arrNum }}",
-                "{{}}": "{{  _.arrNum  }}",
-                "{{}}": "{{  _.arrNum.  }}",
-
-                "{{}}": "{{arrNum.}}",
-                "{{str": "}}",
-                "{{str": }},
-                "arrNum": "{{arrNum[999]}}",
-            }`
-
-            const extraForRegExSpecific =`{
-                "num": {{ num    }}, "num": {{num  }}, "num": {{  num }},
-                                                                "num": {{  num }},
-                "num": {{ num  }},
-                "num": {{
-                    num
-                }},
-                "num": {{num
-                }},
-                "num": {{
-                    num}},
-                "str": {{ s t r }},
-            }`
-
-            assert.equal(substituteEnvironmentVariables(env, input), input)
-            assert.equal(substituteEnvironmentVariables(env, extraForRegExSpecific), extraForRegExSpecific)
-
-        })
-
-        test('Insomnia support', () => {
-            const input =`{
-                "num": {{_.num}},
-                "_num": {{ _.num }},
-
-                "str": "{{_.str}}",
-                "_str": "{{ _.str }}",
-
-                "arr2dMix": [{{_.arr2dMix}}],
-                "arr2dMix_": [ {{ _.arr2dMix }} ],
-
-                "arr2dMix[2][2].keyObj.nestedArr": [{{ _.arr2dMix[2][2].keyObj.nestedArr }}],
-                "arr2dMix[2][2].keyObj.nestedArr[0]": {{_.arr2dMix[2][2].keyObj.nestedArr[0]}},
-
-                "strCamelCase":   "{{_.strCamelCase}}",
-                "str_snake_case": "{{_.str_snake_case}}",
-                "str-kebab-case": "{{_.str-kebab-case}}",
-                "key with space": "{{ _.key with space }}",
-
-                "messyKey": "{{${extremelyMessyKey}}}",
-            }`
-            const expectedOutput = `{
-                "num": ${env.num},
-                "_num": ${env.num},
-
-                "str": "${env.str}",
-                "_str": "${env.str}",
-
-                "arr2dMix": [${stringifyArray(env.arr2dMix)}],
-                "arr2dMix_": [ ${stringifyArray(env.arr2dMix)} ],
-
-                "arr2dMix[2][2].keyObj.nestedArr": [${stringifyArray(env.arr2dMix[2][2].keyObj.nestedArr)}],
-                "arr2dMix[2][2].keyObj.nestedArr[0]": ${env.arr2dMix[2][2].keyObj.nestedArr[0]},
-
-                "strCamelCase":   "${env.strCamelCase}",
-                "str_snake_case": "${env.str_snake_case}",
-                "str-kebab-case": "${env['str-kebab-case']}",
-                "key with space": "${env['key with space']}",
-
-                "messyKey": "${env[extremelyMessyKey]}",
-            }`
-            assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
-        })
-
-        test('Insomnia support will not be used if "_" is present as a key in "environment"', () => {
-            env._ = { someKey: '"_" will be used treated as the key, if its present in the env' }
-
-            const input =`{
-                "_.someKey": {{_.someKey}},
-                "_.someKey": {{ _.someKey }},
-
-                "num": {{_.num}},
-                "_.someKey": {{ _.someKey}},
-                "_.someKey": {{_.someKey }},
-                "_.someKey": {{  _.someKey }},
-                "_.someKey": {{ _.someKey  }},
-                "_.someKey": {{  _.someKey  }},
-            }`
-            const expectedOutput = `{
-                "_.someKey": ${env._.someKey},
-                "_.someKey": ${env._.someKey},
-
-                "num": {{_.num}},
-                "_.someKey": {{ _.someKey}},
-                "_.someKey": {{_.someKey }},
-                "_.someKey": {{  _.someKey }},
-                "_.someKey": {{ _.someKey  }},
-                "_.someKey": {{  _.someKey  }},
-            }`
-            assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
-        })
+            "num": {{_.num}},
+            "_.someKey": {{ _.someKey}},
+            "_.someKey": {{_.someKey }},
+            "_.someKey": {{  _.someKey }},
+            "_.someKey": {{ _.someKey  }},
+            "_.someKey": {{  _.someKey  }},
+        }`
+        assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
     })
 })

--- a/packages/ui/src/helpers.spec.js
+++ b/packages/ui/src/helpers.spec.js
@@ -1,12 +1,29 @@
 import { assert, test, describe, expect } from 'vitest'
-import { substituteEnvironmentVariables } from './helpers.ts'
-
-function stringifyArray(arr) {
-    const arrStr = JSON.stringify(arr)
-    return arrStr.slice(1, arrStr.length-1)
-}
+import { substituteEnvironmentVariables, stringifyArray } from './helpers.ts'
 
 describe ('ui/src/helpers.ts', () => {
+
+    describe(`Function: ${stringifyArray.name}`, () => {
+
+        const arrObj = [
+            [1,2,3],
+            [ 'a', 'b', 'c' ],
+            { keyObj: { nestedObj: 'nest object value', nestedArr: [ 1, 2, 3 ] } }
+        ]
+
+        test('Generic Test', () => {
+            function stringifyArrayTestFunction(arr) {
+                const arrStr = JSON.stringify(arr)
+                return arrStr.slice(1, arrStr.length-1)
+            }
+
+            assert.equal(stringifyArray(arrObj) , stringifyArrayTestFunction(arrObj))
+            for (const subArr of arrObj) {
+                assert.equal(stringifyArray(subArr) , stringifyArrayTestFunction(subArr))
+            }
+        })
+
+    })
 
     describe(`Function: ${substituteEnvironmentVariables.name}`, () => {
 

--- a/packages/ui/src/helpers.spec.js
+++ b/packages/ui/src/helpers.spec.js
@@ -1,39 +1,289 @@
-import { assert, test } from 'vitest'
+import { assert, test, describe, expect } from 'vitest'
 import { substituteEnvironmentVariables } from './helpers.ts'
 
-test('substituteEnvironmentVariables', () => {
-    const environment = {
-        'string': 'cat',
-        'number': 4404,
-        'object': {
-            'string': 'hey',
-            'array': [
-                'r1',
-                'r2',
-                'r3'
-            ]
-        }
-    }
+function stringifyArray(arr) {
+    const arrStr = JSON.stringify(arr)
+    return arrStr.slice(1, arrStr.length-1)
+}
 
-    const json = `{
-        "edge case": "{{",
-        "accessing object path array": "{{ object.array }}",
-        "accessing object path array item": "{{ object.array[0] }}",
-        "access object path string": "{{ object.string }}",
-        "access top level object key": "{{ string }}",
-        "number": {{ number }}
-    }`
+describe ('ui/src/helpers.ts', () => {
 
-    const result = substituteEnvironmentVariables(environment, json)
+    describe(`Function: ${substituteEnvironmentVariables.name}`, () => {
 
-    const expectedResult = `{
-        "edge case": "{{",
-        "accessing object path array": "r1,r2,r3",
-        "accessing object path array item": "r1",
-        "access object path string": "hey",
-        "access top level object key": "cat",
-        "number": 4404
-    }`
+        // build environment vars
+        const env = {}
 
-    assert.equal(result, expectedResult)
+        env.i = 1
+        env.num = 1234
+        env.str = 'This is string'
+
+        env.arrNum = [ 1, 2, 3 ]
+        env.arrStr = [ 'a', 'bb', 'cc' ]
+        env.arrObj = [
+            { keyStr: 'string' },
+            { keyNum: 1 },
+            { keyObj: { nestedObj: 'nest object value', nestedArr: [ 1, 2, 3 ] } }
+        ]
+
+        env.arr2dMix= [ env.arrNum, env.arrStr, env.arrObj ]
+
+        env.strCamelCase      = 'This is camelCase'
+        env.str_snake_case    = 'This is snake-case'
+        env['str-kebab-case'] = 'This is kebab-case'
+        env['key with space'] = 'This key has space'
+
+        const extremelyMessyKey = 'extremelyMESSY-K_E_Y ~!@#$%^&*()_+12 34567980{{} :>}notReplaced::{{  num }}::notReplaced"?<, . shouldReplaceThisInFuture::{{  num   }}::replaced /;\'[ ]'
+        env[ extremelyMessyKey ] = 'Very messy key :)'
+
+
+        test('Positive Case', () => {
+            const input =`{
+                "i": {{i}},
+                "_i": {{ i }},
+
+                "num": {{num}},
+                "_num": {{ num }},
+
+                "str": "{{str}}",
+                "_str": "{{ str }}",
+
+                "arrNum": [{{arrNum}}],
+                "_arrNum": [ {{ arrNum }} ],
+                "arrNum[0]": "{{arrNum[0]}}",
+                "_arrNum[0]": "{{ arrNum[0] }}",
+
+                "arrStr": [{{arrStr}}],
+                "arrStr_": [ {{arrStr}} ],
+                "arrStr[0]": "{{arrStr[0]}}",
+
+                "arrObj[0]": "{{arrObj[0]}}",
+                "arrObj[1]": "{{arrObj[1]}}",
+                "arrObj[2]": "{{arrObj[2]}}",
+                "arrObj[2].keyObj": "{{arrObj[2].keyObj}}",
+
+                "arr2dMix": [{{arr2dMix}}],
+                "arr2dMix_": [ {{arr2dMix}} ],
+
+                "arr2dMix[2][2].keyObj.nestedArr": [{{arr2dMix[2][2].keyObj.nestedArr}}],
+                "arr2dMix[2][2].keyObj.nestedArr[0]": {{arr2dMix[2][2].keyObj.nestedArr[0]}},
+
+                "strCamelCase":   "{{strCamelCase}}",
+                "str_snake_case": "{{str_snake_case}}",
+                "str-kebab-case": "{{str-kebab-case}}",
+                "key with space": "{{key with space}}",
+
+                "messyKey": "{{${extremelyMessyKey}}}",
+            }`
+            const expectedOutput = `{
+                "i": ${env.i},
+                "_i": ${env.i},
+
+                "num": ${env.num},
+                "_num": ${env.num},
+
+                "str": "${env.str}",
+                "_str": "${env.str}",
+
+                "arrNum": [${stringifyArray(env.arrNum)}],
+                "_arrNum": [ ${stringifyArray(env.arrNum)} ],
+                "arrNum[0]": "${env.arrNum[0]}",
+                "_arrNum[0]": "${env.arrNum[0]}",
+
+                "arrStr": [${stringifyArray(env.arrStr)}],
+                "arrStr_": [ ${stringifyArray(env.arrStr)} ],
+                "arrStr[0]": "${env.arrStr[0]}",
+
+                "arrObj[0]": "${JSON.stringify(env.arrObj[0])}",
+                "arrObj[1]": "${JSON.stringify(env.arrObj[1])}",
+                "arrObj[2]": "${JSON.stringify(env.arrObj[2])}",
+                "arrObj[2].keyObj": "${JSON.stringify(env.arrObj[2].keyObj)}",
+
+                "arr2dMix": [${stringifyArray(env.arr2dMix)}],
+                "arr2dMix_": [ ${stringifyArray(env.arr2dMix)} ],
+
+                "arr2dMix[2][2].keyObj.nestedArr": [${stringifyArray(env.arr2dMix[2][2].keyObj.nestedArr)}],
+                "arr2dMix[2][2].keyObj.nestedArr[0]": ${env.arr2dMix[2][2].keyObj.nestedArr[0]},
+
+                "strCamelCase":   "${env.strCamelCase}",
+                "str_snake_case": "${env.str_snake_case}",
+                "str-kebab-case": "${env['str-kebab-case']}",
+                "key with space": "${env['key with space']}",
+
+                "messyKey": "${env[extremelyMessyKey]}",
+            }`
+            assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
+        })
+
+        test('Negative Case', () => {
+            const input =`{
+                "": "",
+                "{": "}",
+                "{{": "}}",
+                "}}": "{{",
+                "{": "}}",
+                "{{": "}",
+                "{ { ": " } }",
+
+                "num": num,
+                "num": {num,
+                "num": num},
+                "num": {num},
+                "num": {{num},
+                "num": {num}},
+
+                "num": { {num}},
+                "num": {{num} },
+                "num": { {num} },
+                "num": { {num } },
+                "num": { { num} },
+                "num": { { num } },
+
+                "num": {{ num}},
+                "num": {{num }},
+
+                "num": {{  num}},
+                "num": {{num  }},
+                "num": {{  num }},
+                "num": {{ num  }},
+                "num": {{  num  }},
+
+                "num": {{
+                    num}},
+                "num": {{num
+                }},
+                "num": {{
+                    num
+                }},
+                "num": {
+                    {num}
+                },
+
+                "num": {
+                    {num
+                }},
+                "num": {{
+                    num}
+                }},
+
+
+                "str": {{ s t r }},
+                "str": {{}},
+                "str": {,
+                "str": {{,
+                "str": {{},
+                "str": {}},
+                "str": {{}},
+                "str": { { } },
+                "str": {  } },
+
+                "-_-": "-_-",
+                "{{}}": "-._.-",
+                "{{}}": "_.",
+                "{{}}": "{{_.}}",
+
+                "{{}}": "{{_. arrNum}}",
+                "{{}}": "{{_ .arrNum}}",
+
+                "{{}}": "{{ _.arrNum  }}",
+                "{{}}": "{{_.arrNum }}",
+                "{{}}": "{{  _.arrNum  }}",
+                "{{}}": "{{  _.arrNum.  }}",
+
+                "{{}}": "{{arrNum.}}",
+                "{{str": "}}",
+                "{{str": }},
+                "arrNum": "{{arrNum[999]}}",
+            }`
+
+            const extraForRegExSpecific =`{
+                "num": {{ num    }}, "num": {{num  }}, "num": {{  num }},
+                                                                "num": {{  num }},
+                "num": {{ num  }},
+                "num": {{
+                    num
+                }},
+                "num": {{num
+                }},
+                "num": {{
+                    num}},
+                "str": {{ s t r }},
+            }`
+
+            assert.equal(substituteEnvironmentVariables(env, input), input)
+            assert.equal(substituteEnvironmentVariables(env, extraForRegExSpecific), extraForRegExSpecific)
+
+        })
+
+        test('Insomnia support', () => {
+            const input =`{
+                "num": {{_.num}},
+                "_num": {{ _.num }},
+
+                "str": "{{_.str}}",
+                "_str": "{{ _.str }}",
+
+                "arr2dMix": [{{_.arr2dMix}}],
+                "arr2dMix_": [ {{ _.arr2dMix }} ],
+
+                "arr2dMix[2][2].keyObj.nestedArr": [{{ _.arr2dMix[2][2].keyObj.nestedArr }}],
+                "arr2dMix[2][2].keyObj.nestedArr[0]": {{_.arr2dMix[2][2].keyObj.nestedArr[0]}},
+
+                "strCamelCase":   "{{_.strCamelCase}}",
+                "str_snake_case": "{{_.str_snake_case}}",
+                "str-kebab-case": "{{_.str-kebab-case}}",
+                "key with space": "{{ _.key with space }}",
+
+                "messyKey": "{{${extremelyMessyKey}}}",
+            }`
+            const expectedOutput = `{
+                "num": ${env.num},
+                "_num": ${env.num},
+
+                "str": "${env.str}",
+                "_str": "${env.str}",
+
+                "arr2dMix": [${stringifyArray(env.arr2dMix)}],
+                "arr2dMix_": [ ${stringifyArray(env.arr2dMix)} ],
+
+                "arr2dMix[2][2].keyObj.nestedArr": [${stringifyArray(env.arr2dMix[2][2].keyObj.nestedArr)}],
+                "arr2dMix[2][2].keyObj.nestedArr[0]": ${env.arr2dMix[2][2].keyObj.nestedArr[0]},
+
+                "strCamelCase":   "${env.strCamelCase}",
+                "str_snake_case": "${env.str_snake_case}",
+                "str-kebab-case": "${env['str-kebab-case']}",
+                "key with space": "${env['key with space']}",
+
+                "messyKey": "${env[extremelyMessyKey]}",
+            }`
+            assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
+        })
+
+        test('Insomnia support will not be used if "_" is present as a key in "environment"', () => {
+            env._ = { someKey: '"_" will be used treated as the key, if its present in the env' }
+
+            const input =`{
+                "_.someKey": {{_.someKey}},
+                "_.someKey": {{ _.someKey }},
+
+                "num": {{_.num}},
+                "_.someKey": {{ _.someKey}},
+                "_.someKey": {{_.someKey }},
+                "_.someKey": {{  _.someKey }},
+                "_.someKey": {{ _.someKey  }},
+                "_.someKey": {{  _.someKey  }},
+            }`
+            const expectedOutput = `{
+                "_.someKey": ${env._.someKey},
+                "_.someKey": ${env._.someKey},
+
+                "num": {{_.num}},
+                "_.someKey": {{ _.someKey}},
+                "_.someKey": {{_.someKey }},
+                "_.someKey": {{  _.someKey }},
+                "_.someKey": {{ _.someKey  }},
+                "_.someKey": {{  _.someKey  }},
+            }`
+            assert.equal(substituteEnvironmentVariables(env, input), expectedOutput)
+        })
+    })
 })

--- a/packages/ui/src/helpers.ts
+++ b/packages/ui/src/helpers.ts
@@ -10,7 +10,7 @@ import { tags } from '@lezer/highlight'
 /**
  * stringifies arr and removes brackets at both ends
  */
-function stringifyArray(arr: any[]): string {
+export function stringifyArray(arr: any[]): string {
     const arrStr = JSON.stringify(arr)
     return arrStr.slice(1, arrStr.length-1)
 }

--- a/packages/ui/src/helpers.ts
+++ b/packages/ui/src/helpers.ts
@@ -58,13 +58,13 @@ export function flattenTree(array) {
     return level
 }
 
-export function substituteEnvironmentVariables(env: object, str: string) {
-    let substitutedString = String(str)
+export function substituteEnvironmentVariables(environment: object, string: string) {
+    let substitutedString = String(string)
 
-    const possibleEnvironmentObjectPaths = getObjectPaths(env)
+    const possibleEnvironmentObjectPaths = getObjectPaths(environment)
 
     possibleEnvironmentObjectPaths.forEach(objectPath => {
-        let objectPathValue:any = getObjectPathValue(env, objectPath)
+        let objectPathValue:any = getObjectPathValue(environment, objectPath)
 
         if (typeof objectPathValue === 'undefined') {
             return
@@ -83,7 +83,7 @@ export function substituteEnvironmentVariables(env: object, str: string) {
          * if "env" doesn't have "_" key, then prefix "objectPath" with "_."
          * and replace occurrences of "_.objectPath"
          */
-        if (!env['_']) {
+        if (!environment['_']) {
             substitutedString = substitutedString.replaceAll(`{{ _.${objectPath} }}`, objectPathValue)
             substitutedString = substitutedString.replaceAll(`{{_.${objectPath}}}`, objectPathValue)
         }

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -55,7 +55,10 @@ export default defineConfig(({ mode }) => {
         define: {
             'process.env': {}
         },
-        base: ''
+        base: '',
+        test: {
+            reporters: 'verbose'
+        }
     }
 
     if(mode === 'desktop') {


### PR DESCRIPTION
## Fixes environment value getting replaced as [object Object] instead of the actual value of the object

### Issue
my environment
```javascript
{ 
  "num": 1,
  "str": "string",
  "obj": { 
    "key": "value"
  }
}
```

![image](https://user-images.githubusercontent.com/50287102/202783103-283d420c-3b01-477f-879e-6cf89a639ee0.png)

<br />

### After fix
![image](https://user-images.githubusercontent.com/50287102/202783769-1e13bfac-8ce1-4cdd-8bc2-d4cba5328605.png)

<br />

### Also contains minor optimization
We no longer fetch all the contents of the env and replace every occurrences one after the other.
Now we simply parse the request body, check for {{envVar}}, then look it up on environment and replace
