### PR TITLE
feat: docker build for web standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:19.8.1-alpine3.17
+RUN mkdir /app
+ADD ./packages/web-standalone /app/web-standalone/
+CMD ["sh","-c","cd /app/web-standalone;npm start"]

--- a/README.md
+++ b/README.md
@@ -144,3 +144,18 @@ npm start
 ```
 
 By default npm start will run Restfox at port 4004. You can override the port by passing port like so `PORT=5040 npm start`.
+
+## Built and used by Docker
+
+First refer to [**Compiling Web Standalone**](#using-web-standalone) to build successfully locally and use it normally.  
+Then in the project root directory (directory with Dockerfile), execute:  
+```
+docker build -t restfox:xx .
+```
+> Note: xx is the version number
+
+After the build is complete, use the following command to start the service:  
+```
+docker run -d -p:4004:4004 restfox:xx
+```
+Visit after successful startup: localhost:4004


### PR DESCRIPTION
Added the docker build and usage method.  
I built a mirror `docker pull kiis/restfox:0.0.7` and haven’t returned to the Readme yet.  
You decide whether to add it to the Readme or build it yourself and add it to the Readme.  
I think there is a direct way The use of docker can avoid the impact caused by the environment.