### PR TITLE
Clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ npm run build
 ## Using web-standalone
 ```
 git clone https://github.com/flawiddsouza/Restfox
-cd packages/ui
+cd Restfox/packages/ui
 npm i
 npm run build-web-standalone
 cd ../web-standalone


### PR DESCRIPTION
If you run the clone instructions for web-standalone as they are, you'll encounter a syntax error. This commit changes that.