### PR TITLE
feat: Add access to the URL and headers from plugin

### DIFF
--- a/packages/ui/src/components/modals/PluginManagerEditModal.vue
+++ b/packages/ui/src/components/modals/PluginManagerEditModal.vue
@@ -38,12 +38,20 @@ const examplePluginCode =
 // context.request.getMethod()
 // context.request.getEnvironmentVariable('<ENVIRONMENT_VARIABLE_NAME>')
 // context.request.setEnvironmentVariable('<ENVIRONMENT_VARIABLE_NAME>', '<ENVIRONMENT_VARIABLE_VALUE>')
+// context.request.getHeader('<HEADER_NAME>')
+// context.request.setHeader('<HEADER_NAME>', '<HEADER_VALUE>') - sets header value
+// context.request.getHeaders()
+// context.request.setHeaders(<HEADER_ARRAY>) - replaces all headers with contents of <HEADER_ARRAY>
+// context.request.getURL()
 // context.request.getBody()
 // context.request.setBody(<REQUEST_BODY_OBJECT>)
 // context.request.getQueryParams()
 // context.request.setQueryParams(<REQUEST_QUERY_PARAMS_ARRAY>)
 // context.response.getEnvironmentVariable('<ENVIRONMENT_VARIABLE_NAME>')
 // context.response.setEnvironmentVariable('<ENVIRONMENT_VARIABLE_NAME>', '<ENVIRONMENT_VARIABLE_VALUE>')
+// context.response.getHeader('<HEADER_NAME>')
+// context.response.getHeaders()
+// context.response.getURL()
 // context.response.getBody() - returns ArrayBuffer
 // context.response.setBody(<RESPONSE_BODY_ARRAY_BUFFER>)
 // context.response.getBodyText() - returns context.response.getBody() ArrayBuffer as text

--- a/packages/ui/src/helpers.ts
+++ b/packages/ui/src/helpers.ts
@@ -281,7 +281,7 @@ export async function createRequestData(state, request, environment, setEnvironm
             code: plugin.code
         })
 
-        request = { ...request, body: requestContext.request.getBody(), parameters: requestContext.request.getQueryParams() }
+        request = { ...request, headers: requestContext.request.getHeaders(), body: requestContext.request.getBody(), parameters: requestContext.request.getQueryParams() }
     }
 
     let body: any = null

--- a/packages/ui/src/plugin.js
+++ b/packages/ui/src/plugin.js
@@ -2,6 +2,7 @@ import { getQuickJS } from 'quickjs-emscripten'
 import { Arena } from 'quickjs-emscripten-sync'
 import getObjectPathValue from 'lodash.get'
 import chai from 'chai'
+import { substituteEnvironmentVariables } from './helpers'
 
 const test = (testResults) => (description, callback) => {
     try {
@@ -61,6 +62,27 @@ export function createRequestContextForPlugin(request, environment, setEnvironme
                 },
                 setQueryParams(queryParams) {
                     state.parameters = queryParams
+                },
+                getURL() {
+                    return substituteEnvironmentVariables(environment, state.url)
+                },
+                getHeaders() {
+                    return state.headers
+                },
+                setHeaders(requestHeaders) {
+                    state.headers = requestHeaders
+                },
+                getHeader(headerName) {
+                    var header = state.headers.find((header) => header.name.toLowerCase() == headerName.toLowerCase())
+                    return header ? substituteEnvironmentVariables(environment, header.value) : undefined
+                },
+                setHeader(headerName, value) {
+                    var headerIndex = state.headers.findIndex((header) => header.name.toLowerCase() == headerName.toLowerCase())
+                    if(headerIndex >= 0) {
+                        state.headers[headerIndex].value = value
+                    } else {
+                        state.headers.push({ name: headerName, value: value })
+                    }
                 }
             }
         },
@@ -74,6 +96,7 @@ export function createRequestContextForPlugin(request, environment, setEnvironme
 
 export function createResponseContextForPlugin(response, environment, setEnvironmentVariable, testResults) {
     let bufferCopy = response.buffer.slice(0)
+    let headers = response.headers
 
     return {
         context: {
@@ -95,6 +118,16 @@ export function createResponseContextForPlugin(response, environment, setEnviron
                 },
                 setEnvironmentVariable(objectPath, value) {
                     setEnvironmentVariable(objectPath, value)
+                },
+                getURL() {
+                    return response.url
+                },
+                getHeaders() {
+                    return headers
+                },
+                getHeader(headerName) {
+                    var header = headers.find((header) => header[0].toLowerCase() == headerName.toLowerCase())
+                    return header ? substituteEnvironmentVariables(environment, header[1]) : undefined
                 }
             }
         },

--- a/packages/ui/src/plugin.js
+++ b/packages/ui/src/plugin.js
@@ -127,7 +127,7 @@ export function createResponseContextForPlugin(response, environment, setEnviron
                 },
                 getHeader(headerName) {
                     var header = headers.find((header) => header[0].toLowerCase() == headerName.toLowerCase())
-                    return header ? substituteEnvironmentVariables(environment, header[1]) : undefined
+                    return header ? header[1] : undefined
                 }
             }
         },


### PR DESCRIPTION
I've taken the liberty of adding a few plugin methods that would allow access to the URL and headers of requests and responses. This also allows setting headers for requests via plugins but responses are read-only. This PR adds the following methods:

Request methods:
- context.request.getHeader('<HEADER_NAME>')
- context.request.setHeader('<HEADER_NAME>', '<HEADER_VALUE>')
- context.request.getHeaders()
- context.request.setHeaders(<HEADER_ARRAY>)
- context.request.getURL()

Response methods:
- context.response.getHeader('<HEADER_NAME>')
- context.response.getHeaders()
- context.response.getURL()
