### PR TITLE
Allow native wayland options to support HiDPI screens that using fractional scaling (snap builds)

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -37,7 +37,7 @@
         "lint-fix": "eslint src/*.ts --fix",
         "make": "electron-forge make",
         "publish": "electron-forge publish",
-        "build-snap": "electron-builder --linux snap --c.snap.allowNativeWayland true --publish never ",
+        "build-snap": "electron-builder --linux snap --publish never --c.snap.allowNativeWayland true",
         "build-appx": "electron-builder --windows appx"
     },
     "dependencies": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -37,7 +37,7 @@
         "lint-fix": "eslint src/*.ts --fix",
         "make": "electron-forge make",
         "publish": "electron-forge publish",
-        "build-snap": "electron-builder --linux snap --publish never --c.snap.allowNativeWayland true",
+        "build-snap": "electron-builder --linux snap --publish never",
         "build-appx": "electron-builder --windows appx"
     },
     "dependencies": {
@@ -65,6 +65,9 @@
             "publisher": "CN=C01B6C7C-C0E3-4A87-B162-83B3296CA0E6",
             "publisherDisplayName": "Artelin",
             "applicationId": "Artelin.Restfox"
+        },
+        "snap": {
+            "allowNativeWayland": true
         },
         "files": [
             "**/*",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -37,7 +37,7 @@
         "lint-fix": "eslint src/*.ts --fix",
         "make": "electron-forge make",
         "publish": "electron-forge publish",
-        "build-snap": "electron-builder --linux snap --publish never",
+        "build-snap": "electron-builder --linux snap --c.snap.allowNativeWayland true --publish never ",
         "build-appx": "electron-builder --windows appx"
     },
     "dependencies": {


### PR DESCRIPTION
Apparently more people are using larger screen nowadays and they tend to use fractional scaling (especially in wayland). This is what happened when we use electron through xwayland compositor:

![image](https://github.com/flawiddsouza/Restfox/assets/44611397/0b7f5242-c85e-4fdb-a61f-56ce1e7e41dc)

![image](https://github.com/flawiddsouza/Restfox/assets/44611397/2f1fa044-8be4-4fc8-83b0-0cd7260f4ed6)

Both images are preserving its size and also the screenshot, but the second picture was taken from the 2.5K monitor and appears to be blurred.

Electron on the other hand already supports native wayland settings so can address this issue by providing simple Execute command:

`/usr/bin/env ELECTRON_OZONE_PLATFORM_HINT=auto restfox`

But because your `electron-build` config (especially snap) doesn't support wayland, so the command line wouldn't work and triggers segmentation error.

![image](https://github.com/flawiddsouza/Restfox/assets/44611397/ab73c448-c185-4beb-a738-fbddb7dd8972)

This PR just simply added `allowNativeWayland` option on snap build so we can activate `ELECTRON_OZONE_PLATFORM_HINT` env.