### PR TITLE
ci(docker): tag new version as latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Build and tag docker image
         working-directory: .
         run: |
-          docker build -t flawiddsouza/restfox:${{ env.VERSION }} .
+          docker build -t flawiddsouza/restfox:${{ env.VERSION }} -t flawiddsouza/restfox:latest .
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -126,7 +126,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish docker image
         run: |
-          docker push flawiddsouza/restfox:${{ env.VERSION }}
+          docker push -a flawiddsouza/restfox:${{ env.VERSION }}
   update-release-notes:
     needs: [build-electron-linux]
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish docker image
         run: |
-          docker push -a flawiddsouza/restfox:${{ env.VERSION }}
+          docker push --all-tags flawiddsouza/restfox
   update-release-notes:
     needs: [build-electron-linux]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should tag versions as latest as they are created (assuming you never run this for a version that's already been published).

I haven't tested it per se, but the push should include all tags, and since we're building in a completely blank environment, it should only possess the latest Docker image.

See if you can test these commands locally first @flawiddsouza to ensure nothing is pushed that we wouldn't want 🙏🏼 