### PR TITLE
feat: add user-agent to headers

### DIFF
--- a/packages/ui/src/components/RequestPanelHeaders.vue
+++ b/packages/ui/src/components/RequestPanelHeaders.vue
@@ -37,11 +37,12 @@
 </template>
 
 <script setup lang="ts">
-import { PropType } from 'vue'
+import { onMounted, PropType } from 'vue'
 import CodeMirrorSingleLine from './CodeMirrorSingleLine.vue'
 import { CollectionItem } from '@/global'
+import { version } from '../../../electron/package.json'
 
-defineProps({
+const { collectionItem, collectionItemEnvironmentResolved } = defineProps({
     collectionItem: {
         type: Object as PropType<CollectionItem>,
         required: true
@@ -51,6 +52,17 @@ defineProps({
         required: true
     }
 })
+
+onMounted(() => {
+    addDefaultHeader()
+})
+
+function addDefaultHeader() {
+    if (!collectionItem.headers) {
+        collectionItem.headers = []
+        collectionItem.headers.push({ name: 'User-Agent', value: `Restfox/${version}`, disabled: false })
+    }
+}
 
 function pushItem(object: any, key: string, itemToPush: any) {
     if(key in object === false) {

--- a/packages/ui/src/components/RequestPanelHeaders.vue
+++ b/packages/ui/src/components/RequestPanelHeaders.vue
@@ -37,12 +37,11 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, PropType } from 'vue'
+import { PropType } from 'vue'
 import CodeMirrorSingleLine from './CodeMirrorSingleLine.vue'
 import { CollectionItem } from '@/global'
-import { version } from '../../../electron/package.json'
 
-const { collectionItem, collectionItemEnvironmentResolved } = defineProps({
+defineProps({
     collectionItem: {
         type: Object as PropType<CollectionItem>,
         required: true
@@ -52,17 +51,6 @@ const { collectionItem, collectionItemEnvironmentResolved } = defineProps({
         required: true
     }
 })
-
-onMounted(() => {
-    addDefaultHeader()
-})
-
-function addDefaultHeader() {
-    if (!collectionItem.headers) {
-        collectionItem.headers = []
-        collectionItem.headers.push({ name: 'User-Agent', value: `Restfox/${version}`, disabled: false })
-    }
-}
 
 function pushItem(object: any, key: string, itemToPush: any) {
     if(key in object === false) {

--- a/packages/ui/src/helpers.ts
+++ b/packages/ui/src/helpers.ts
@@ -23,6 +23,7 @@ import {
     OpenApiSpecPathParams,
 } from './global'
 import { ActionContext } from 'vuex'
+import { version } from '../../electron/package.json'
 
 // From: https://stackoverflow.com/a/67802481/4932305
 export function toTree(array: CollectionItem[]): CollectionItem[] {
@@ -486,6 +487,10 @@ export async function handleRequest(
 
     try {
         const { url, headers, body } = await createRequestData(state, request, environment, parentHeaders, parentAuthentication, setEnvironmentVariable, plugins, workspaceLocation)
+
+        if (!headers['user-agent']) {
+            headers['user-agent'] = `Restfox/${getVersion()}`
+        }
 
         const response = await fetchWrapper(url, request.method!, headers, body, abortControllerSignal, flags)
 
@@ -1604,4 +1609,8 @@ export function getAlertConfirmPromptContainer(componentRootElement: HTMLElement
     createAlert: any
 } {
     return (componentRootElement.ownerDocument?.defaultView ?? window).document.querySelector('alert-confirm-prompt') as any
+}
+
+export function getVersion(): string {
+    return version
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -16,7 +16,8 @@
             "DOM.Iterable",
         ],
         "target": "es2022",
-        "noEmit": true
+        "noEmit": true,
+        "resolveJsonModule": true
     },
     "include": [
         "src/**/*.ts",


### PR DESCRIPTION
if user doesn't specify the user-agent header, restfox would add it to the request to help the server identify Restfox as the HTTP requesting application or client.

![Screenshot 2024-05-07 at 10 39 24](https://github.com/flawiddsouza/Restfox/assets/7845001/b6a9150d-9334-43ef-ad96-7e0a139e32e4)
