### PR TITLE
fix: repeated headers get dropped

### DIFF
--- a/packages/ui/src/helpers.ts
+++ b/packages/ui/src/helpers.ts
@@ -442,17 +442,13 @@ export async function createRequestData(
         const enabledHeaders = request.headers.filter(header => !header.disabled)
         for(const header of enabledHeaders) {
             const headerName = (await substituteEnvironmentVariables(environment, header.name, { cacheId })).toLowerCase()
-            let headerValue = await substituteEnvironmentVariables(environment, header.value, { cacheId })
+            const headerValue = await substituteEnvironmentVariables(environment, header.value, { cacheId })
 
             if(body instanceof FormData && headerName === 'content-type') { // exclude content-type header for multipart/form-data
                 continue
             }
 
             if(headerName !== '') {
-                if(headerValue.includes(',')) {
-                    //interpret value as continues string (ignoring the inner comma) | https://www.rfc-editor.org/rfc/rfc9110.html#quoted.strings
-                    headerValue = `"${headerValue}"`
-                }
                 if(headerName in headers) {
                     //allow multiple headers with the same name by concatenating the values with ", " | https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2
                     headers[headerName] += `, ${headerValue}`
@@ -472,7 +468,7 @@ export async function createRequestData(
         const buffer = []
         for(const value of headerValues) {
             const headerValue = await substituteEnvironmentVariables(environment, value, { cacheId })
-            buffer.push(headerValue.includes(',') ? `"${headerValue}"` : headerValue)
+            buffer.push(headerValue)
         }
         const mergedValues = buffer.join(', ')
         headers[headerName] = mergedValues

--- a/packages/ui/src/utils/generate-code.ts
+++ b/packages/ui/src/utils/generate-code.ts
@@ -14,7 +14,7 @@ export function getAvailableTargets() {
 export async function generateCode(
     request: CollectionItem,
     environment: any,
-    parentHeaders: Record<string, string>,
+    parentHeaders: Record<string, string[]>,
     parentAuthentication: RequestAuthentication | undefined,
     target: 'shell',
     clientId: 'curl'


### PR DESCRIPTION
Addresses #321 
When the same header name is defined multiple times, all the definitions are compressed into a comma separated list of values (according to [RFC/9110-section-5.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2))

On the request preview the values are not shown separately, however the original request object does have each header defined individually and parsed correctly
<details>
<summary>Original Resquest Headers (screenshot)</summary>

![Pasted image 20250512210140](https://github.com/user-attachments/assets/1f9c71ff-0e83-44e6-bfdd-d352cce44e8e)

</details>

It also works on folders (or any parent) and the headers will follow the hierarchy order, that is, if a folder defines a header named `X-Custom-Header` as `x-value` and a request inside that folder defines `X-Custom-Header` as `y-value` the end request will have the header `x-value, y-value` (the parent is defined first)

Note: when substituting parent header names the end name would be lower-cased but when substituting the _leaf_ header object (the request headers object) the header name would **not** be lower-cased. For sake of consistency (and correctness) now everything is lower cased

---
### Testing
Manual test on the browser and running electron locally
- Google chrome: Version 136.0.7103.93
- OS: Windows 10
---

### Preview:
![image](https://github.com/user-attachments/assets/4613004c-3d91-4982-b8ff-0a93e3469ec1)
