### PR TITLE
fix(ui): Switching to empty workspaces does not reload collection items

### DIFF
--- a/packages/ui/src/App.vue
+++ b/packages/ui/src/App.vue
@@ -110,7 +110,7 @@ export default {
             this.appLoaded = true
             this.activeWorkspaceLoaded = true
 
-            if(collections.length > 0) {
+            if(collections.length >= 0) {
                 this.$store.commit('setCollection', collections)
             }
 


### PR DESCRIPTION
Due to the collections.length is 0 with empty workspace, this condition is not reachable.


https://github.com/user-attachments/assets/32a7f301-ef53-43a5-9f37-9358148f1074

