### PR TITLE
fix(TabBar): prevent middle click from pasting clipboard text into focused body

### DIFF
--- a/packages/ui/src/components/TabBar.vue
+++ b/packages/ui/src/components/TabBar.vue
@@ -9,7 +9,8 @@
             :class="{ 'tab-active': activeTab && activeTab._id === tab._id }"
             v-for="tab in tabs"
             @click="setActiveTab(tab)"
-            @mousedown.middle.prevent="closeTab(tab)"
+            @mousedown.middle.prevent.stop
+            @mouseup.middle.prevent.stop="closeTab(tab)"
             :data-id="tab._id"
             draggable="true"
             @contextmenu.prevent="handleTabContextMenu($event, tab)"

--- a/packages/ui/tests/App_test.ts
+++ b/packages/ui/tests/App_test.ts
@@ -119,3 +119,24 @@ Scenario('Test env var autocompletion', async() => {
     await checkAutocompleteInBetween('{{ca}}', '{{ca', 't', '{{cat}}')
     await checkAutocompleteInBetween('ca}}', 'ca', 't', '{{cat}}')
 })
+
+Scenario('Middle clicking a tab should not paste clipboard text into focused body', async ({ I }) => {
+    const bodyTab = '[data-testid="request-panel-tab-Body"]';
+
+    I.createRequest('Tab1');
+    I.click(bodyTab);
+
+    I.createGraphQLRequest('Tab2');
+    I.fillRequestBody
+
+    await I.fillRequestBody('Tab2 text');
+
+    I.click('.code-mirror-editor .cm-content');
+
+    await I.middleClickTab('Tab1');
+
+    I.dontSee('Tab1', '.tab');
+
+    const currentText = await I.getRequestBodyText();
+    I.expectEqual(currentText.trim() === 'Tab2 text', true);
+});

--- a/packages/ui/tests/steps_file.ts
+++ b/packages/ui/tests/steps_file.ts
@@ -43,5 +43,28 @@ export = function() {
             this.fillField('.code-mirror-editor .cm-content', JSON.stringify(obj))
             this.click('Done')
         },
+
+        async middleClickTab(name: string) {
+            await this.usePlaywrightTo('middle click tab', async ({ page }) => {
+                await page.locator('.tab').filter({ hasText: name }).click({ button: 'middle' });
+            });
+        },
+
+        async fillRequestBody(text: string) {
+            this.click('.code-mirror-editor .cm-content')
+            this.pressKey(['CommandOrControl', 'A'])
+            this.pressKey('Backspace')
+            this.type(text)
+        },
+
+        async getRequestBodyText() {
+            return await this.grabTextFrom('.code-mirror-editor .cm-content')
+        },
+
+        async selectAllAndCopy() {
+            this.click('.code-mirror-editor .cm-content')
+            this.pressKey(['CommandOrControl', 'A'])
+            this.pressKey(['CommandOrControl', 'C'])
+        },
     })
 }


### PR DESCRIPTION
## Description
In Firefox browser, the problem didn't occur. Otherwise, on Chrome, the problem persisted. Because the tab element is immediately destroyed upon the `mousedown` event, the subsequent `mouseup` or `auxclick` events fall through to the underlying active element (the `CodeMirror` request body editor). This causes whatever text is currently in the user's clipboard to be accidentally pasted into the request body of the newly focused tab.

## The solution
- Updated `packages/ui/src/components/TabBar.vue` to properly handle the middle-click event lifecycle.
- Replaced the standard click handler with `@mousedown.middle.prevent.stop` and `@mouseup.middle.prevent.stop="closeTab(tab)".`

- This explicitly intercepts the middle-click on the tab, calls `preventDefault()` to stop the browser's native paste action at its origin, and safely closes the tab upon mouse release without the event bubbling down to the editor.

## Evidences
### Before
https://jam.dev/c/935823f9-ba72-49d0-b549-5910a0bf0139
### After
https://jam.dev/c/0235d07e-90db-4e33-be5f-89f7a6c6f02d

## Testing
- Added a new E2E test scenario in packages/ui/tests/App_test.ts to prevent future regressions.

- The test initializes a GraphQL request (to ensure the body editor is open by default), copies a "toxic" string to the clipboard, opens a second tab, and performs a native Playwright middle-click to close the previous tab. It then asserts that the clipboard text did not leak into the active editor.

- Added new helper methods (`middleClickTab`, `selectAllAndCopy`, `fillRequestBody`, `getRequestBodyText`) to `packages/ui/tests/steps_file.ts` to support this testing flow.

## Related issue
- resolves #360 