### PR TITLE
feat(ui): reorder environments

### DIFF
--- a/packages/ui/src/components/modals/EnvironmentModal.vue
+++ b/packages/ui/src/components/modals/EnvironmentModal.vue
@@ -14,21 +14,23 @@
                 <div class="env-sidebar-col">
                     <button class="button" type="button" style="margin-bottom: 0.5rem; margin-right: 0.5rem;" @click="addEnvironment()">Add Environment</button>
                     <div style="overflow-y: auto;" class="environment-sidebar">
-                        <div v-for="(environment, index) in environments" :key="environment.name" 
-                            class="environment-sidebar-item" 
-                            :class="{ 'environment-sidebar-item-active': environment.name === currentEnvironment }" 
-                            @click="changeEnvironment(environment)" 
+                        <div
+                            v-for="(environment, index) in environments" :key="environment.name"
+                            class="environment-sidebar-item"
+                            :class="{ 'environment-sidebar-item-active': environment.name === currentEnvironment }"
+                            @click="changeEnvironment(environment)"
                             :ref="'environment-' + environment.name"
                             draggable="true"
                             @dragstart="onDragStart(index, $event)"
                             @dragover.prevent
                             @dragenter.prevent
                             @drop="onDrop(index)"
-                            @dragend="onDragEnd">
+                            @dragend="onDragEnd"
+                        >
                             <div style="display: flex; align-items: center;">
                                 <i class="fa fa-circle" :style="{ color: environment.color, marginRight: '0.5rem' }"></i>{{ environment.name }}
                             </div>
-                           
+
                             <div class="environment-sidebar-item-menu" :class="{ 'environment-sidebar-item-menu-disable-hide': environment.name === clickedContextMenuEnvironment.name && showEnvironmentContextMenuPopup === true }" @click.stop="showEnvironmentContextMenu($event, environment)">
                                 <svg viewBox="0 0 24 24" focusable="false" style="pointer-events: none; display: block; width: 100%; height: 100%;">
                                     <g>


### PR DESCRIPTION
Closes #377 

Implemented the drag-and-drop logic so that the users can reorder the environments the way they want. I also added a drag handle icon to the left of the environment name to make it clearer that the feature exists.

<img width="205" height="129" alt="print1-contribuicao3" src="https://github.com/user-attachments/assets/8c7f9c0b-68f9-4a36-9fb3-ebe1efd47627" />

Dragging Prod to the top of the list
<img width="243" height="148" alt="print2-contribuicao3" src="https://github.com/user-attachments/assets/61326bfe-6693-4c07-83f0-dd8daae6b3a4" />
