### PR TITLE
Fix #350: Replace path.extname() with .endsWith('.json') check

### DIFF
--- a/packages/electron/src/db.js
+++ b/packages/electron/src/db.js
@@ -427,10 +427,8 @@ async function updateCollection(workspace, collectionId, updatedFields) {
         const renameFrom = collectionPath
         let renameTo = path.join(path.dirname(collectionPath), updatedFields.name)
 
-        const extension = path.extname(renameFrom)
-
-        if (extension) {
-            renameTo += extension
+        if (renameFrom.endsWith('.json')) {
+            renameTo += '.json'
         }
 
         if (renameFrom === renameTo) {

--- a/packages/web-standalone/src/db.js
+++ b/packages/web-standalone/src/db.js
@@ -267,8 +267,7 @@ async function updateCollection(workspace, collectionId, updatedFields) {
         updatedFields.name = fileUtils.encodeFilename(updatedFields.name)
         const renameFrom = collectionPath
         let renameTo = path.join(path.dirname(collectionPath), updatedFields.name)
-        const extension = path.extname(renameFrom)
-        if (extension) { renameTo += extension }
+        if (renameFrom.endsWith('.json')) { renameTo += '.json' }
         if (renameFrom === renameTo) { return { error: null } }
         if(await fileUtils.pathExists(renameTo)) { return { error: `An item of the same name already exists in the destination folder. Please rename the item and try again.` } }
         await fileUtils.renameFileOrFolder(renameFrom, renameTo, fsLog, `Rename collection item`, null)


### PR DESCRIPTION
When renaming items, path.extname() incorrectly treated folder names with dots (e.g. test.folder) as having extensions, appending them to the new path and causing duplications like test.folders.folder.

Since only .json files need extension preservation and folders are bare directories, replace the blind path.extname() check with an explicit endsWith('.json') check.

Changes:
- packages/electron/src/db.js: updateCollection function
- packages/web-standalone/src/db.js: updateCollection function

Issue card - https://github.com/flawiddsouza/Restfox/issues/350